### PR TITLE
11:Fragment View

### DIFF
--- a/src/components/hint.tsx
+++ b/src/components/hint.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+interface HintProps {
+  children: React.ReactNode;
+  text: string;
+  side?: "top" | "right" | "bottom" | "left";
+  align?: "start" | "center" | "end";
+}
+
+export const Hint = ({
+  children,
+  text,
+  side = "top",
+  align = "center",
+}: HintProps) => {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>{children}</TooltipTrigger>
+        <TooltipContent side={side} align={align}>
+          <p>{text}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+};

--- a/src/modules/projects/ui/components/fragment-web.tsx
+++ b/src/modules/projects/ui/components/fragment-web.tsx
@@ -1,0 +1,65 @@
+import { Fragment } from "@/generated/prisma";
+import { useState } from "react";
+import { ExternalLinkIcon, RefreshCcwIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Hint } from "@/components/hint";
+
+interface Props {
+  data: Fragment;
+}
+
+export function FragmentWeb({ data }: Props) {
+  const [copied, setCopied] = useState(false);
+  const [fragmentKey, setFragmentKey] = useState(0);
+
+  const onRefresh = () => {
+    setFragmentKey((prev) => prev + 1);
+  };
+  const handlecopy = () => {
+    navigator.clipboard.writeText(data.sandboxUrl);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+  return (
+    <div className="flex flex-col w-full h-full">
+      <div className="p-2 border-b bg-sidebar flex items-center gap-x-2 ">
+        <Hint text="Refresh" side="bottom" align="start">
+          <Button size="sm" variant="outline" onClick={onRefresh}>
+            <RefreshCcwIcon />
+          </Button>
+        </Hint>
+        <Hint text="Click to Copy" side="bottom">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={handlecopy}
+            disabled={!data.sandboxUrl || copied}
+            className="flex-1 justify-start text-start font-normal"
+          >
+            <span className="truncate">{data.sandboxUrl}</span>
+          </Button>
+        </Hint>
+        <Hint text="Open in a new tab" side="bottom" align="start">
+          <Button
+            size="sm"
+            disabled={!data.sandboxUrl}
+            variant="outline"
+            onClick={() => {
+              if (!data.sandboxUrl) return;
+              window.open(data.sandboxUrl, "_blank");
+            }}
+          >
+            <ExternalLinkIcon />
+          </Button>
+        </Hint>
+      </div>
+      <iframe
+        key={fragmentKey}
+        className="h-full w-full"
+        sandbox="allow-form allow-scripts allow-same-origin"
+        loading="lazy"
+        src={data.sandboxUrl}
+      />
+    </div>
+  );
+}

--- a/src/modules/projects/ui/views/project-view.tsx
+++ b/src/modules/projects/ui/views/project-view.tsx
@@ -11,6 +11,7 @@ import { MessagesContainer } from "../components/messages-container";
 import { Suspense, useState } from "react";
 import { Fragment } from "@/generated/prisma";
 import { ProjectHeader } from "../components/project-header";
+import { FragmentWeb } from "../components/fragment-web";
 
 interface Props {
   projectId: string;
@@ -39,7 +40,7 @@ export const ProjectView = ({ projectId }: Props) => {
         </ResizablePanel>
         <ResizableHandle withHandle />
         <ResizablePanel defaultSize={65} minSize={50}>
-          TODO :Preview
+          {!!activeFragment && <FragmentWeb data={activeFragment} />}
         </ResizablePanel>
       </ResizablePanelGroup>
     </div>


### PR DESCRIPTION
## Summary by Sourcery

Add a web-based fragment preview to the project view with sandbox controls and tooltips

New Features:
- Introduce FragmentWeb component to display a fragment sandbox in an iframe with refresh, copy, and open controls
- Render FragmentWeb in the ProjectView panel when an active fragment is present
- Add Hint component for showing tooltips on interactive buttons